### PR TITLE
link check corrections

### DIFF
--- a/check_links_md.sh
+++ b/check_links_md.sh
@@ -2,29 +2,29 @@
 
 for file in $(find /raw -name '*.md')
 do 
-    #echo $file
     for line in $(cat $file)
     do
-       if [[ $line == [http* ]]
-       then
-           #echo $line
-           url=`echo $line | cut -d "(" -f2 | cut -d ")" -f1`
-           #echo $url
+        if [[ $line == *"](http"* ]]
+        then
+            url=`echo $line | egrep -o '\]\(h.*)' | sed 's|[]()]||g'`
 
-           status_code=$(curl -o -I -L -s -w "%{http_code}\n" $url)
-           #echo $status_code
+            # bail out on private repos
+            if [[ ("$url" == *"docker-training/exercises"*) || ("$url" == *"docker-training/presentations"*) || ("$url" == *"docker-training/communication-templates"*) ]]
+            then
+                continue
+            fi
 
-          if [ $status_code -ge "200" ] && [ $status_code -lt "300" ]
-          then
-               #echo "status check succeeded"
-               :
-           else
-               echo $file
-               echo "broken url:" $url
-               echo "---"
-           fi
-       fi
+            status_code=$(curl -o -I -L -s -w "%{http_code}\n" $url)
 
+            if [[ $status_code -ge "200" ]] && [[ $status_code -lt "300" ]]
+            then
+                :
+            else
+                echo $file
+                echo "broken url:" $url
+                echo "---"
+            fi
+        fi
     done
 done 
 


### PR DESCRIPTION
heya @xijing-zhang, here are a few ideas for your link checker:

 - you were finding candidates with `if [[ $line == [http* ]]`; this would only find stuff at the beginning of a line. You need a leading `*` at least; I went for `if [[ $line == *"](http"* ]]` (putting the full `](` construction in front of the `http` for higher specificity == less accidental matches).
 -  Your slicing `` url=`echo $line | cut -d "(" -f2 | cut -d ")" -f1` `` was geting tripped up on markdown links inside of brackets; see `([https://tools.ietf.org/html/rfc3339](https://tools.ietf.org/html/rfc3339)` from the 'cleaning up docker resources', for example.
 - I inserted a by-hand exception for the private docker repos; not the most elegant solution, but now I get the satisfying no-output when everything is good.